### PR TITLE
fix get_all_class_method undefined error

### DIFF
--- a/iOS/iOSFridaLib.js
+++ b/iOS/iOSFridaLib.js
@@ -247,7 +247,7 @@ function find_symbol_from_address(modulePath,addr){
     var allClass = get_all_objc_class(modulePath);
     
     for(var i = 0, len = allClass.length; i < len; i++){
-        var mInfo = get_all_class_method(allClass[i]);
+        var mInfo = get_all_class_methods(allClass[i]);
         var curClassName = allClass[i]
         
         var objms = mInfo[0];

--- a/iOS/sample/iOS-app-hook.py
+++ b/iOS/sample/iOS-app-hook.py
@@ -5,7 +5,7 @@ import codecs
 import os
 import threading
 
-NAME_OR_BUNDLEID = "cn.xiaobu.pipiPlay"
+NAME_OR_BUNDLEID = "com.tencent.xin"
 
 def do_hook():
     return xCallStackSymbolsTest()
@@ -39,7 +39,7 @@ def get_applications(device):
     try:
         applications = device.enumerate_applications()
     except Exception as e:
-        print 'Failed to enumerate applications: %s' % e
+        print('Failed to enumerate applications: %s' % e)
         return
 
     return applications
@@ -61,7 +61,7 @@ def get_usb_iphone():
     while device is None:
         devices = [dev for dev in device_manager.enumerate_devices() if dev.type == Type]
         if len(devices) == 0:
-            print 'Waiting for USB device...'
+            print('Waiting for USB device...')
             changed.wait()
         else:
             device = devices[0]
@@ -102,7 +102,7 @@ if __name__ == '__main__':
             script.load()
             sys.stdin.read()
         except Exception as e:
-            print e
+            print(e)
 
     except KeyboardInterrupt:
         sys.exit(0)

--- a/iOS/sample/xCallStackSymbols.js
+++ b/iOS/sample/xCallStackSymbols.js
@@ -2,26 +2,19 @@ if (ObjC.available)
 {
     try
     {
-        //hook - ZYOperationView operationCopyLink
-        var className = "ZYMediaDownloadHelper";
-        var funcName = "+ downloadMediaUrl:isVideo:progress:finishBlock:";
-        var hook = eval('ObjC.classes.' + className + '["' + funcName + '"]');
+        if ("WCBaseCgi" in ObjC.classes) {
+            // -[WCBaseCgi setRequest:]
+            var WCBaseCgi = ObjC.classes.WCBaseCgi;
+            var setRequest = WCBaseCgi["- setRequest:"];
         
-        Interceptor.attach(hook.implementation, {
-            onEnter: function(args) {
-                // args[0] is self
-                // args[1] is selector (SEL "sendMessageWithText:")
-                // args[2] holds the first function argument, an NSString
-
-                // just call [NSThread callStackSymbols]
-                var threadClass = ObjC.classes.NSThread
-                var symbols = threadClass["+ callStackSymbols"]()
-                XLOG(symbols)
-                
-                // call  xCallStackSymbols
-                xbacktrace(this.context);
-            }
-        });
+            Interceptor.attach(setRequest.implementation, {
+                onEnter: function (args) {
+                    var arg2 = ObjC.Object(args[2]); //GetUserHistoryPageRequest
+                    console.log('-[WCBaseCgi setRequest:' + arg2 + ']');
+                    xbacktrace(this.context);
+                }
+            });
+        }
     }
     catch(err)
     {


### PR DESCRIPTION
执行 iOSFridaLib.js  报错，修复 get_all_class_method 方法未定义错误。

`
{'type': 'error', 'description': "ReferenceError: identifier 'get_all_class_method' undefined", 'stack': "ReferenceError: identifier 'get_all_class_method' undefined\n    at [anon] (../../../frida-gum/bindings/gumjs/duktape.c:83728)\n    at find_symbol_from_address (/script1.js:250)\n    at xbacktrace (/script1.js:379)\n    at /script1.js:403", 'fileName': '/script1.js', 'lineNumber': 250, 'columnNumber': 1}
`